### PR TITLE
feat(template): add Walter/Readable-style GA setup with placeholder ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You might also want to set the publisher domain to ucdavis.edu and fill in the o
 
 ### Google Analytics (GA4)
 
-This template includes GA4 wiring in the same style as Walter/Readable:
+This template includes GA4 wiring:
 
 - GA bootstrap script is in `client/index.html`
 - Route-change page view tracking is in `client/src/shared/analytics/AnalyticsListener.tsx`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ When you are ready to get your own, go to [Microsoft Entra ID](https://entra.mic
 
 You might also want to set the publisher domain to ucdavis.edu and fill in the other general branding info.
 
+### Google Analytics (GA4)
+
+This template includes GA4 wiring in the same style as Walter/Readable:
+
+- GA bootstrap script is in `client/index.html`
+- Route-change page view tracking is in `client/src/shared/analytics/AnalyticsListener.tsx`
+
+A placeholder measurement ID is included by default:
+
+- `G-XXXXXXXXXX`
+
+Before using this template in a real app, replace `G-XXXXXXXXXX` in `client/index.html` with your real GA4 measurement ID in **both** places:
+
+1. `https://www.googletagmanager.com/gtag/js?id=...`
+2. `gtag('config', '...')`
+
 ### Health check
 
 The health check endpoint (`/health`) is configured to return the status of the application and its dependencies. It includes a database health check to ensure the SQL Server connection is healthy. See [Health Checks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-9.0#entity-framework-core-dbcontext-probe).

--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,21 @@
   <link rel="icon" type="image/svg+xml" href="/thumbnail.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Web App Template</title>
+
+  <!-- Google tag (gtag.js) -->
+  <script
+    async
+    src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"
+  ></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+
+    gtag('config', 'G-XXXXXXXXXX', { send_page_view: false });
+  </script>
 </head>
 
 <body data-theme='gunrock' className='antialiased'>

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -2,9 +2,11 @@ import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import { RouterContext } from '../main.tsx';
+import { AnalyticsListener } from '@/shared/analytics/AnalyticsListener.tsx';
 
 const RootLayout = () => (
   <>
+    <AnalyticsListener />
     <Outlet />
     <ReactQueryDevtools buttonPosition="top-right" />
     <TanStackRouterDevtools position="bottom-right" />

--- a/client/src/shared/analytics/AnalyticsListener.tsx
+++ b/client/src/shared/analytics/AnalyticsListener.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+export function AnalyticsListener() {
+  const router = useRouter();
+
+  useEffect(() => {
+    window.gtag?.('event', 'page_view', {
+      page_path: window.location.pathname,
+    });
+
+    return router.subscribe('onResolved', () => {
+      const path = window.location.pathname;
+
+      window.gtag?.('event', 'page_view', {
+        page_path: path,
+      });
+    });
+  }, [router]);
+
+  return null;
+}

--- a/client/src/types/gtag.d.ts
+++ b/client/src/types/gtag.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[][];
+    gtag?: (...args: unknown[]) => void;
+  }
+}


### PR DESCRIPTION
## Summary
Set up Google Analytics in the template using the same pattern now used in Walter and Readable.

## Changes
- Add GA bootstrap script to `client/index.html`
- Use a generic placeholder GA4 ID: `G-XXXXXXXXXX`
- Add route-change page view tracking via `AnalyticsListener`
- Wire `AnalyticsListener` into the root route layout
- Add `client/src/types/gtag.d.ts` for `window.gtag` typing
- Document where to update the GA token/measurement ID in `README.md`

## README docs added
A new **Google Analytics (GA4)** section explains:
- where GA is configured
- the placeholder ID used by default
- exactly which two places to replace with a real ID

## Validation
- `cd client && npm test -- --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Analytics 4 integration with automatic page‑view tracking across route navigation; includes a default placeholder measurement ID.

* **Documentation**
  * Updated README with GA4 setup and instructions to replace the placeholder measurement ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->