### PR TITLE
Organizes SPA source files in the Visual Studio project tree

### DIFF
--- a/server/server.csproj
+++ b/server/server.csproj
@@ -35,7 +35,7 @@
     <!-- Show the frontend source tree in Visual Studio without requiring a separate .esproj. -->
     <Content Remove="$(SpaRoot)**" />
     <None Remove="$(SpaRoot)**" />
-    <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
+    <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" LinkBase="client" />
     <ProjectReference Include="..\server.core\server.core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Sets LinkBase="client" so that the frontend source files are grouped under a virtual "client" folder in the Solution Explorer instead of appearing at the project root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project build configuration to optimize how frontend files are organized and displayed in the development environment with no impact on application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->