### PR TITLE
feat: add data table export example and CSV utilities

### DIFF
--- a/client/src/lib/csv.ts
+++ b/client/src/lib/csv.ts
@@ -1,0 +1,130 @@
+type CsvValue = string | number | boolean | null | undefined;
+
+interface CsvOptions {
+  includeBom?: boolean;
+  lineEnding?: '\n' | '\r\n';
+}
+
+export type CsvFormat = 'currency' | 'date';
+
+export interface CsvColumn<T> {
+  format?: CsvFormat;
+  header: string;
+  key: keyof T;
+}
+
+function escapeCsvValue(value: CsvValue): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value);
+
+  if (
+    stringValue.includes(',') ||
+    stringValue.includes('"') ||
+    stringValue.includes('\n')
+  ) {
+    return `"${stringValue.replaceAll('"', '""')}"`;
+  }
+
+  return stringValue;
+}
+
+function formatDateValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') {
+    return '';
+  }
+
+  const stringValue = String(value);
+  const isoDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(stringValue);
+
+  if (isoDateMatch) {
+    const [, year, month, day] = isoDateMatch;
+    return `${month}/${day}/${year}`;
+  }
+
+  const date = new Date(stringValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatCurrencyValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') {
+    return '';
+  }
+
+  const numberValue = Number(value);
+
+  if (!Number.isFinite(numberValue)) {
+    return String(value);
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).format(numberValue);
+}
+
+function formatValue(value: unknown, format?: CsvFormat): string {
+  if (format === 'date') {
+    return formatDateValue(value);
+  }
+
+  if (format === 'currency') {
+    return formatCurrencyValue(value);
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value);
+}
+
+export function toCsv<T>(
+  rows: T[],
+  columns: CsvColumn<T>[],
+  options?: CsvOptions
+): string {
+  const lineEnding = options?.lineEnding ?? '\n';
+  const headers = columns.map((column) => escapeCsvValue(column.header)).join(',');
+  const dataRows = rows.map((row) =>
+    columns
+      .map((column) =>
+        escapeCsvValue(formatValue(row[column.key], column.format))
+      )
+      .join(',')
+  );
+  const csv = [headers, ...dataRows].join(lineEnding);
+
+  return options?.includeBom ? `\ufeff${csv}` : csv;
+}
+
+export function toExcelCsv<T>(rows: T[], columns: CsvColumn<T>[]): string {
+  return toCsv(rows, columns, { includeBom: true, lineEnding: '\r\n' });
+}
+
+export function downloadCsv(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = filename;
+  link.click();
+
+  URL.revokeObjectURL(url);
+}
+
+export function downloadExcelCsv(content: string, filename: string): void {
+  downloadCsv(content, filename);
+}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as authenticatedRouteRouteImport } from './routes/(authenticated)/route'
 import { Route as authenticatedIndexRouteImport } from './routes/(authenticated)/index'
+import { Route as authenticatedTableExportRouteImport } from './routes/(authenticated)/table-export'
 import { Route as authenticatedStylesRouteImport } from './routes/(authenticated)/styles'
 import { Route as authenticatedMeRouteImport } from './routes/(authenticated)/me'
 import { Route as authenticatedFormRouteImport } from './routes/(authenticated)/form'
@@ -31,6 +32,12 @@ const authenticatedIndexRoute = authenticatedIndexRouteImport.update({
   path: '/',
   getParentRoute: () => authenticatedRouteRoute,
 } as any)
+const authenticatedTableExportRoute =
+  authenticatedTableExportRouteImport.update({
+    id: '/table-export',
+    path: '/table-export',
+    getParentRoute: () => authenticatedRouteRoute,
+  } as any)
 const authenticatedStylesRoute = authenticatedStylesRouteImport.update({
   id: '/styles',
   path: '/styles',
@@ -59,6 +66,7 @@ export interface FileRoutesByFullPath {
   '/form': typeof authenticatedFormRoute
   '/me': typeof authenticatedMeRoute
   '/styles': typeof authenticatedStylesRoute
+  '/table-export': typeof authenticatedTableExportRoute
 }
 export interface FileRoutesByTo {
   '/about': typeof AboutRoute
@@ -66,6 +74,7 @@ export interface FileRoutesByTo {
   '/form': typeof authenticatedFormRoute
   '/me': typeof authenticatedMeRoute
   '/styles': typeof authenticatedStylesRoute
+  '/table-export': typeof authenticatedTableExportRoute
   '/': typeof authenticatedIndexRoute
 }
 export interface FileRoutesById {
@@ -76,13 +85,21 @@ export interface FileRoutesById {
   '/(authenticated)/form': typeof authenticatedFormRoute
   '/(authenticated)/me': typeof authenticatedMeRoute
   '/(authenticated)/styles': typeof authenticatedStylesRoute
+  '/(authenticated)/table-export': typeof authenticatedTableExportRoute
   '/(authenticated)/': typeof authenticatedIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/fetch' | '/form' | '/me' | '/styles'
+  fullPaths:
+    | '/'
+    | '/about'
+    | '/fetch'
+    | '/form'
+    | '/me'
+    | '/styles'
+    | '/table-export'
   fileRoutesByTo: FileRoutesByTo
-  to: '/about' | '/fetch' | '/form' | '/me' | '/styles' | '/'
+  to: '/about' | '/fetch' | '/form' | '/me' | '/styles' | '/table-export' | '/'
   id:
     | '__root__'
     | '/(authenticated)'
@@ -91,6 +108,7 @@ export interface FileRouteTypes {
     | '/(authenticated)/form'
     | '/(authenticated)/me'
     | '/(authenticated)/styles'
+    | '/(authenticated)/table-export'
     | '/(authenticated)/'
   fileRoutesById: FileRoutesById
 }
@@ -120,6 +138,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof authenticatedIndexRouteImport
+      parentRoute: typeof authenticatedRouteRoute
+    }
+    '/(authenticated)/table-export': {
+      id: '/(authenticated)/table-export'
+      path: '/table-export'
+      fullPath: '/table-export'
+      preLoaderRoute: typeof authenticatedTableExportRouteImport
       parentRoute: typeof authenticatedRouteRoute
     }
     '/(authenticated)/styles': {
@@ -158,6 +183,7 @@ interface authenticatedRouteRouteChildren {
   authenticatedFormRoute: typeof authenticatedFormRoute
   authenticatedMeRoute: typeof authenticatedMeRoute
   authenticatedStylesRoute: typeof authenticatedStylesRoute
+  authenticatedTableExportRoute: typeof authenticatedTableExportRoute
   authenticatedIndexRoute: typeof authenticatedIndexRoute
 }
 
@@ -166,6 +192,7 @@ const authenticatedRouteRouteChildren: authenticatedRouteRouteChildren = {
   authenticatedFormRoute: authenticatedFormRoute,
   authenticatedMeRoute: authenticatedMeRoute,
   authenticatedStylesRoute: authenticatedStylesRoute,
+  authenticatedTableExportRoute: authenticatedTableExportRoute,
   authenticatedIndexRoute: authenticatedIndexRoute,
 }
 

--- a/client/src/routes/(authenticated)/index.tsx
+++ b/client/src/routes/(authenticated)/index.tsx
@@ -52,6 +52,21 @@ function RouteComponent() {
             </div>
             <div className="card bg-base-100 shadow-md">
               <div className="card-body">
+                <h3 className="card-title">Data Table Export Example</h3>
+                <p className="text-base-content/70">
+                  This page demonstrates a Walter-style export flow, with table
+                  actions separated from the DataTable and CSV columns defined
+                  alongside the data model.
+                </p>
+                <div className="card-actions justify-end">
+                  <Link className="btn btn-primary" to="/table-export">
+                    Go to Export Page
+                  </Link>
+                </div>
+              </div>
+            </div>
+            <div className="card bg-base-100 shadow-md">
+              <div className="card-body">
                 <h3 className="card-title">Form Example</h3>
                 <p className="text-base-content/70">
                   This page demonstrates custom form components with TanStack

--- a/client/src/routes/(authenticated)/table-export.tsx
+++ b/client/src/routes/(authenticated)/table-export.tsx
@@ -1,0 +1,154 @@
+import { useQuery } from '@tanstack/react-query';
+import { type ColumnDef } from '@tanstack/react-table';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { type CsvColumn } from '@/lib/csv.ts';
+import { fetchJson } from '@/lib/api.ts';
+import { DataTable } from '@/shared/dataTable.tsx';
+import { ExportDataButton } from '@/shared/exportDataButton.tsx';
+
+export const Route = createFileRoute('/(authenticated)/table-export')({
+  component: TableExportExample,
+});
+
+interface Forecast {
+  date: string;
+  summary: string;
+  temperatureC: number;
+  temperatureF: number;
+}
+
+const columns: ColumnDef<Forecast>[] = [
+  {
+    accessorKey: 'date',
+    header: 'Date',
+  },
+  {
+    accessorKey: 'temperatureC',
+    header: 'Temp. (C)',
+  },
+  {
+    accessorKey: 'temperatureF',
+    header: 'Temp. (F)',
+  },
+  {
+    accessorKey: 'summary',
+    header: 'Summary',
+  },
+];
+
+const csvColumns: CsvColumn<Forecast>[] = [
+  {
+    format: 'date',
+    header: 'Date',
+    key: 'date',
+  },
+  {
+    header: 'Temperature (C)',
+    key: 'temperatureC',
+  },
+  {
+    header: 'Temperature (F)',
+    key: 'temperatureF',
+  },
+  {
+    header: 'Summary',
+    key: 'summary',
+  },
+];
+
+function TableExportExample() {
+  const weatherQuery = useQuery({
+    queryFn: () => fetchJson<Forecast[]>('/api/weatherforecast'),
+    queryKey: ['weather', 'table-export'],
+    staleTime: 5 * 60_000,
+  });
+
+  const contents =
+    weatherQuery.data === undefined ? (
+      <div className="flex items-center justify-center p-8">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+          <p className="text-gray-600 italic">
+            Loading... Please refresh once the ASP.NET backend has started. See{' '}
+            <a
+              className="text-blue-600 underline hover:text-blue-800"
+              href="https://aka.ms/jspsintegrationreact"
+            >
+              https://aka.ms/jspsintegrationreact
+            </a>{' '}
+            for more details.
+          </p>
+        </div>
+      </div>
+    ) : (
+      <DataTable
+        columns={columns}
+        data={weatherQuery.data}
+        globalFilter="left"
+        initialState={{ pagination: { pageSize: 5 } }}
+        tableActions={(table) => {
+          const hasActiveFilter =
+            String(table.getState().globalFilter ?? '').trim() !== '';
+          const filteredRows = table
+            .getFilteredRowModel()
+            .rows.map((row) => row.original);
+
+          return (
+            <div className="flex flex-wrap items-center gap-2">
+              <ExportDataButton
+                columns={csvColumns}
+                data={weatherQuery.data}
+                filename="weather-forecast.csv"
+              />
+              {hasActiveFilter ? (
+                <ExportDataButton
+                  columns={csvColumns}
+                  data={filteredRows}
+                  filename="weather-forecast-filtered.csv"
+                  label="Export filtered"
+                />
+              ) : null}
+            </div>
+          );
+        }}
+      />
+    );
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+      <div className="absolute top-4 left-4 z-10">
+        <Link className="btn btn-ghost btn-sm" to="/">
+          <svg
+            className="mr-2 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 12l2-2m0 0 7-7 7 7M5 10v10a1 1 0 001 1h3m10-11 2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+          </svg>
+          Home
+        </Link>
+      </div>
+
+      <div className="w-full max-w-5xl space-y-8">
+        <div>
+          <h1 className="mb-4 text-3xl font-bold text-gray-900">
+            Weather forecast with export
+          </h1>
+          <p className="mb-6 text-gray-600">
+            This example keeps the existing fetch pattern, then adds a toolbar
+            export button using separate CSV column definitions similar to
+            Walter.
+          </p>
+          {contents}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/shared/dataTable.tsx
+++ b/client/src/shared/dataTable.tsx
@@ -1,5 +1,6 @@
 'use no memo';
 
+import type { ReactNode } from 'react';
 import {
   ColumnDef,
   flexRender,
@@ -8,22 +9,30 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   InitialTableState,
+  type Table,
   useReactTable,
 } from '@tanstack/react-table';
+
+type TableActionsRenderer<TData extends object> =
+  | ReactNode
+  | ((table: Table<TData>) => ReactNode);
 
 interface DataTableProps<TData extends object> {
   columns: ColumnDef<TData>[];
   data: TData[];
+  filterPlaceholder?: string;
   globalFilter?: 'left' | 'right' | 'none'; // Controls the position of the search box
   initialState?: InitialTableState; // Optional initial state for the table, use for stuff like setting page size or sorting
-  // ...any other props, initial state?, export? pages? filter? sorting?
+  tableActions?: TableActionsRenderer<TData>;
 }
 
 export const DataTable = <TData extends object>({
   columns,
   data,
+  filterPlaceholder = 'Search all columns...',
   globalFilter = 'right',
   initialState,
+  tableActions,
 }: DataTableProps<TData>) => {
   // see note in https://tanstack.com/table/latest/docs/installation#react-table.  Added "use no memo" just to be safe but it's unnecessary.
   // once tanstack updates their docs and makes sure it works w/ react compiler (even though we aren't using it yet), we can remove this comment
@@ -40,53 +49,67 @@ export const DataTable = <TData extends object>({
     },
   });
 
-  return (
-    <div className="space-y-4">
-      {globalFilter !== 'none' && (
-        <div
-          className={`flex items-center ${globalFilter === 'right' ? 'justify-end' : 'justify-start'}`}
+  const filterControl =
+    globalFilter === 'none' ? null : (
+      <label className="input input-bordered flex items-center gap-2 w-full max-w-sm">
+        <svg
+          className="h-[1em] opacity-50"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <label className="input input-bordered flex items-center gap-2 w-full max-w-sm">
+          <g
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2.5"
+          >
+            <circle cx="11" cy="11" r="8"></circle>
+            <path d="m21 21-4.3-4.3"></path>
+          </g>
+        </svg>
+        <input
+          className="grow"
+          onChange={(e) => table.setGlobalFilter(e.target.value)}
+          placeholder={filterPlaceholder}
+          type="text"
+          value={table.getState().globalFilter ?? ''}
+        />
+        {table.getState().globalFilter && (
+          <button
+            className="btn btn-ghost btn-sm btn-circle"
+            onClick={() => table.setGlobalFilter('')}
+            type="button"
+          >
             <svg
-              className="h-[1em] opacity-50"
-              viewBox="0 0 24 24"
+              className="h-4 w-4"
+              fill="currentColor"
+              viewBox="0 0 16 16"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <g
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2.5"
-              >
-                <circle cx="11" cy="11" r="8"></circle>
-                <path d="m21 21-4.3-4.3"></path>
-              </g>
+              <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
             </svg>
-            <input
-              className="grow"
-              onChange={(e) => table.setGlobalFilter(e.target.value)}
-              placeholder="Search all columns..."
-              type="text"
-              value={table.getState().globalFilter ?? ''}
-            />
-            {table.getState().globalFilter && (
-              <button
-                className="btn btn-ghost btn-sm btn-circle"
-                onClick={() => table.setGlobalFilter('')}
-                type="button"
-              >
-                <svg
-                  className="h-4 w-4"
-                  fill="currentColor"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
-                </svg>
-              </button>
-            )}
-          </label>
+          </button>
+        )}
+      </label>
+    );
+
+  const resolvedTableActions =
+    typeof tableActions === 'function' ? tableActions(table) : tableActions;
+
+  const toolbarItems =
+    globalFilter === 'left'
+      ? [filterControl, resolvedTableActions]
+      : [resolvedTableActions, filterControl];
+  const hasToolbar = toolbarItems.some(Boolean);
+
+  return (
+    <div className="space-y-4">
+      {hasToolbar && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          {toolbarItems.map((item, index) =>
+            item ? <div key={index}>{item}</div> : null
+          )}
         </div>
       )}
 

--- a/client/src/shared/exportDataButton.tsx
+++ b/client/src/shared/exportDataButton.tsx
@@ -1,0 +1,47 @@
+import { type CsvColumn, downloadExcelCsv, toExcelCsv } from '@/lib/csv.ts';
+
+interface ExportDataButtonProps<T> {
+  className?: string;
+  columns: CsvColumn<T>[];
+  data: T[];
+  filename: string;
+  label?: string;
+}
+
+export function ExportDataButton<T>({
+  className = '',
+  columns,
+  data,
+  filename,
+  label = 'Export',
+}: ExportDataButtonProps<T>) {
+  const handleExport = () => {
+    const csv = toExcelCsv(data, columns);
+    downloadExcelCsv(csv, filename);
+  };
+
+  return (
+    <button
+      className={`btn btn-sm ${className}`.trim()}
+      onClick={handleExport}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 16V4m0 12 4-4m-4 4-4-4M5 20h14"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+        />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/client/src/test/lib/csv.test.ts
+++ b/client/src/test/lib/csv.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { toExcelCsv } from '@/lib/csv.ts';
+
+describe('csv utilities', () => {
+  it('formats excel-friendly csv output with escaping and a BOM', () => {
+    const csv = toExcelCsv(
+      [
+        {
+          amount: 1234.5,
+          date: '2024-07-04',
+          summary: 'Sunny, "bright"',
+        },
+      ],
+      [
+        { format: 'date', header: 'Date', key: 'date' },
+        { format: 'currency', header: 'Amount', key: 'amount' },
+        { header: 'Summary', key: 'summary' },
+      ]
+    );
+
+    expect(csv.startsWith('\ufeffDate,Amount,Summary\r\n')).toBe(true);
+    expect(csv).toContain('07/04/2024');
+    expect(csv).toContain('"1,234.50"');
+    expect(csv).toContain('"Sunny, ""bright"""');
+  });
+});

--- a/client/src/test/routes/(authenticated)/table-export.test.tsx
+++ b/client/src/test/routes/(authenticated)/table-export.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { downloadExcelCsv } from '@/lib/csv.ts';
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+
+vi.mock('@/lib/csv.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/csv.ts')>();
+
+  return {
+    ...actual,
+    downloadExcelCsv: vi.fn(),
+  };
+});
+
+describe('table export route', () => {
+  it('shows the filtered export action only when a filter is active', async () => {
+    const forecasts = [
+      {
+        date: '2024-07-04',
+        summary: 'Sunny',
+        temperatureC: 25,
+        temperatureF: 77,
+      },
+      {
+        date: '2024-07-05',
+        summary: 'Rainy',
+        temperatureC: 16,
+        temperatureF: 61,
+      },
+    ];
+
+    let weatherRequestCount = 0;
+    let userRequestCount = 0;
+
+    server.use(
+      http.get('/api/weatherforecast', () => {
+        weatherRequestCount += 1;
+        return HttpResponse.json(forecasts);
+      }),
+      http.get('/api/user/me', () => {
+        userRequestCount += 1;
+        return HttpResponse.json({ id: 'user-1' });
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/table-export' });
+
+    try {
+      expect(
+        await screen.findByText('Weather forecast with export')
+      ).toBeInTheDocument();
+      expect(await screen.findByText('Sunny')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Export filtered' })
+      ).not.toBeInTheDocument();
+
+      fireEvent.input(screen.getByPlaceholderText('Search all columns...'), {
+        target: { value: 'Sunny' },
+      });
+
+      expect(
+        await screen.findByRole('button', { name: 'Export filtered' })
+      ).toBeInTheDocument();
+      expect(weatherRequestCount).toBe(1);
+      expect(userRequestCount).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('exports only filtered rows when the filtered export button is used', async () => {
+    const forecasts = [
+      {
+        date: '2024-07-04',
+        summary: 'Sunny',
+        temperatureC: 25,
+        temperatureF: 77,
+      },
+      {
+        date: '2024-07-05',
+        summary: 'Rainy',
+        temperatureC: 16,
+        temperatureF: 61,
+      },
+    ];
+
+    server.use(
+      http.get('/api/weatherforecast', () => HttpResponse.json(forecasts)),
+      http.get('/api/user/me', () => HttpResponse.json({ id: 'user-1' }))
+    );
+
+    const downloadExcelCsvMock = vi.mocked(downloadExcelCsv);
+    downloadExcelCsvMock.mockClear();
+
+    const { cleanup } = renderRoute({ initialPath: '/table-export' });
+
+    try {
+      await screen.findByText('Weather forecast with export');
+      await screen.findByText('Sunny');
+
+      fireEvent.input(screen.getByPlaceholderText('Search all columns...'), {
+        target: { value: 'Sunny' },
+      });
+
+      fireEvent.click(
+        await screen.findByRole('button', { name: 'Export filtered' })
+      );
+
+      expect(downloadExcelCsvMock).toHaveBeenCalledTimes(1);
+
+      const csv = downloadExcelCsvMock.mock.calls[0]?.[0];
+      const filename = downloadExcelCsvMock.mock.calls[0]?.[1];
+
+      expect(csv).toContain('Sunny');
+      expect(csv).not.toContain('Rainy');
+      expect(csv).toContain('07/04/2024');
+      expect(filename).toBe('weather-forecast-filtered.csv');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Introduces a CSV generation library and an `ExportDataButton` component to facilitate data exports. The `DataTable` component was updated to support a `tableActions` prop for toolbar customization, enabling the export of both full and filtered datasets as demonstrated in a new example page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added data table export functionality with support for CSV and Excel-compatible formats.
  * Created a new "Data Table Export Example" page demonstrating export capabilities.
  * Users can now export entire datasets or filtered results from data tables to CSV files.
  * Export feature includes automatic formatting for dates and currency values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->