### PR TITLE
feat: add email notification example with a data table

### DIFF
--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ const authenticatedFetchRoute = authenticatedFetchRouteImport.update({
 } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof authenticatedIndexRoute
   '/about': typeof AboutRoute
   '/fetch': typeof authenticatedFetchRoute
   '/form': typeof authenticatedFormRoute
@@ -74,7 +75,6 @@ export interface FileRoutesByFullPath {
   '/notification': typeof authenticatedNotificationRoute
   '/styles': typeof authenticatedStylesRoute
   '/table-export': typeof authenticatedTableExportRoute
-  '/': typeof authenticatedIndexRoute
 }
 export interface FileRoutesByTo {
   '/about': typeof AboutRoute
@@ -101,6 +101,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/about'
     | '/fetch'
     | '/form'
@@ -108,7 +109,6 @@ export interface FileRouteTypes {
     | '/notification'
     | '/styles'
     | '/table-export'
-    | '/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/about'
@@ -148,8 +148,8 @@ declare module '@tanstack/react-router' {
     }
     '/(authenticated)': {
       id: '/(authenticated)'
-      path: ''
-      fullPath: ''
+      path: '/'
+      fullPath: '/'
       preLoaderRoute: typeof authenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/client/src/routes/(authenticated)/notification.tsx
+++ b/client/src/routes/(authenticated)/notification.tsx
@@ -87,7 +87,6 @@ function NotificationRoute() {
   );
 
   const handleSendTableExample = async () => {
-    sendNotificationMutation.reset();
     sendTableNotificationMutation.reset();
 
     try {
@@ -327,16 +326,21 @@ function NotificationRoute() {
                     endpoint and renders the total in the last row of the email.
                   </p>
                   <button
-                    className="btn btn-outline btn-primary self-start"
+                    className="btn btn-primary self-start"
                     disabled={sendTableNotificationMutation.isPending}
                     onClick={() => {
                       void handleSendTableExample();
                     }}
                     type="button"
                   >
-                    {sendTableNotificationMutation.isPending
-                      ? 'Sending Table Example...'
-                      : 'Send Table Example Email'}
+                    {sendTableNotificationMutation.isPending ? (
+                      <>
+                        <span className="loading loading-spinner loading-xs mr-2"></span>
+                        Sending Table Example...
+                      </>
+                    ) : (
+                      'Send Table Example Email'
+                    )}
                   </button>
                 </div>
               </div>

--- a/client/src/routes/(authenticated)/notification.tsx
+++ b/client/src/routes/(authenticated)/notification.tsx
@@ -20,14 +20,26 @@ type NotificationResponse = {
   to: string;
 };
 
+type TableNotificationRow = {
+  title: string;
+  details: string;
+  amount: number;
+};
+
+type TableNotificationRequest = {
+  header: string;
+  message: string;
+  rows: TableNotificationRow[];
+  subject: string;
+  to: string;
+  totalAmount: number;
+};
+
 const notificationSchema = z.object({
   header: z.string().min(1, 'Header is required'),
   message: z.string().min(1, 'Message is required'),
   subject: z.string().min(1, 'Subject is required'),
-  to: z.union([
-    z.literal(''),
-    z.email('Please enter a valid email address'),
-  ]),
+  to: z.union([z.literal(''), z.email('Please enter a valid email address')]),
 }) satisfies z.ZodType<NotificationForm>;
 
 function NotificationRoute() {
@@ -36,6 +48,14 @@ function NotificationRoute() {
   const sendNotificationMutation = useMutation({
     mutationFn: async (value: NotificationForm) =>
       fetchJson<NotificationResponse>('/api/notification/default', {
+        body: JSON.stringify(value),
+        method: 'POST',
+      }),
+  });
+
+  const sendTableNotificationMutation = useMutation({
+    mutationFn: async (value: TableNotificationRequest) =>
+      fetchJson<NotificationResponse>('/api/notification/table', {
         body: JSON.stringify(value),
         method: 'POST',
       }),
@@ -62,6 +82,22 @@ function NotificationRoute() {
   });
 
   const errorMessage = getErrorMessage(sendNotificationMutation.error);
+  const tableErrorMessage = getErrorMessage(
+    sendTableNotificationMutation.error
+  );
+
+  const handleSendTableExample = async () => {
+    sendNotificationMutation.reset();
+    sendTableNotificationMutation.reset();
+
+    try {
+      await sendTableNotificationMutation.mutateAsync(
+        buildTableExampleRequest()
+      );
+    } catch {
+      // The mutation state already captures and renders API failures for the page.
+    }
+  };
 
   return (
     <div className="min-h-screen bg-base-100">
@@ -81,8 +117,8 @@ function NotificationRoute() {
           </h1>
           <p className="mx-auto max-w-3xl text-xl text-base-content/70">
             This page exercises the reusable email notification system that
-            lives in <code>server.core</code>. The page keeps the request
-            path easy to trace while showing where to add real templates and
+            lives in <code>server.core</code>. The page keeps the request path
+            easy to trace while showing where to add real templates and
             service-level notification logic in a new app.
           </p>
         </header>
@@ -142,12 +178,16 @@ function NotificationRoute() {
 
               <div className="card bg-base-200 shadow-sm">
                 <div className="card-body">
-                  <h3 className="card-title text-lg">Starter files to inspect</h3>
+                  <h3 className="card-title text-lg">
+                    Starter files to inspect
+                  </h3>
                   <div className="space-y-3 text-sm text-base-content/70">
                     <p>
                       Shared layout:
                       <br />
-                      <code>server.core/Views/Shared/_NotificationLayout_mjml.cshtml</code>
+                      <code>
+                        server.core/Views/Shared/_NotificationLayout_mjml.cshtml
+                      </code>
                     </p>
                     <p>
                       Default template:
@@ -274,12 +314,93 @@ function NotificationRoute() {
                   <span>{errorMessage}</span>
                 </div>
               ) : null}
+
+              <div className="divider my-8">Table template example</div>
+
+              <div className="card bg-base-200 shadow-sm">
+                <div className="card-body gap-4">
+                  <h3 className="card-title text-lg">
+                    Send the 5-row table email
+                  </h3>
+                  <p className="text-sm text-base-content/70">
+                    This posts five dummy rows to the dedicated table template
+                    endpoint and renders the total in the last row of the email.
+                  </p>
+                  <button
+                    className="btn btn-outline btn-primary self-start"
+                    disabled={sendTableNotificationMutation.isPending}
+                    onClick={() => {
+                      void handleSendTableExample();
+                    }}
+                    type="button"
+                  >
+                    {sendTableNotificationMutation.isPending
+                      ? 'Sending Table Example...'
+                      : 'Send Table Example Email'}
+                  </button>
+                </div>
+              </div>
+
+              {sendTableNotificationMutation.isSuccess ? (
+                <div className="alert alert-success mt-6">
+                  <span>
+                    Table example email sent to{' '}
+                    <strong>{sendTableNotificationMutation.data.to}</strong>.
+                  </span>
+                </div>
+              ) : null}
+
+              {tableErrorMessage ? (
+                <div className="alert alert-error mt-6">
+                  <span>{tableErrorMessage}</span>
+                </div>
+              ) : null}
             </div>
           </article>
         </section>
       </div>
     </div>
   );
+}
+
+function buildTableExampleRequest(): TableNotificationRequest {
+  const rows: TableNotificationRow[] = [
+    {
+      title: 'Discovery workshop',
+      details: 'Stakeholder interviews and scope alignment',
+      amount: 125,
+    },
+    {
+      title: 'UI design',
+      details: 'Wireframes, review, and component specs',
+      amount: 240,
+    },
+    {
+      title: 'Frontend build',
+      details: 'Route wiring and shared component integration',
+      amount: 180,
+    },
+    {
+      title: 'Backend API',
+      details: 'Notification endpoint and MJML template data',
+      amount: 95,
+    },
+    {
+      title: 'QA pass',
+      details: 'Template verification and regression checks',
+      amount: 310,
+    },
+  ];
+
+  return {
+    header: 'Five-row statement example',
+    message:
+      'This example shows how a dedicated MJML template can render dynamic rows and a separately supplied total.',
+    rows,
+    subject: 'Table notification example',
+    to: '',
+    totalAmount: rows.reduce((sum, row) => sum + row.amount, 0),
+  };
 }
 
 function getErrorMessage(error: unknown) {

--- a/client/src/test/routes/(authenticated)/notification.test.tsx
+++ b/client/src/test/routes/(authenticated)/notification.test.tsx
@@ -204,7 +204,33 @@ describe('notification route', () => {
         to: '',
         totalAmount: 950,
       });
-      expect(postedBody?.rows).toHaveLength(5);
+      expect(postedBody?.rows).toEqual([
+        {
+          title: 'Discovery workshop',
+          details: 'Stakeholder interviews and scope alignment',
+          amount: 125,
+        },
+        {
+          title: 'UI design',
+          details: 'Wireframes, review, and component specs',
+          amount: 240,
+        },
+        {
+          title: 'Frontend build',
+          details: 'Route wiring and shared component integration',
+          amount: 180,
+        },
+        {
+          title: 'Backend API',
+          details: 'Notification endpoint and MJML template data',
+          amount: 95,
+        },
+        {
+          title: 'QA pass',
+          details: 'Template verification and regression checks',
+          amount: 310,
+        },
+      ]);
     } finally {
       cleanup();
     }

--- a/client/src/test/routes/(authenticated)/notification.test.tsx
+++ b/client/src/test/routes/(authenticated)/notification.test.tsx
@@ -54,7 +54,9 @@ describe('notification route', () => {
         screen.getByRole('button', { name: 'Send Notification Email' })
       );
 
-      expect(await screen.findByText('preview@example.com')).toBeInTheDocument();
+      expect(
+        await screen.findByText('preview@example.com')
+      ).toBeInTheDocument();
       expect(postedBody).toMatchObject({
         header: 'Client test header',
         message: 'Client test message',
@@ -87,7 +89,9 @@ describe('notification route', () => {
     const { cleanup } = renderRoute({ initialPath: '/notification' });
 
     try {
-      await screen.findByText('Razor templates, MJML, and SMTP in one shared flow');
+      await screen.findByText(
+        'Razor templates, MJML, and SMTP in one shared flow'
+      );
 
       fireEvent.input(
         screen.getByPlaceholderText('Leave blank to use the current user'),
@@ -108,7 +112,9 @@ describe('notification route', () => {
         screen.getByRole('button', { name: 'Send Notification Email' })
       );
 
-      expect(await screen.findByText('explicit@example.com')).toBeInTheDocument();
+      expect(
+        await screen.findByText('explicit@example.com')
+      ).toBeInTheDocument();
       expect(postedBody).toMatchObject({
         to: 'explicit@example.com',
       });
@@ -142,7 +148,9 @@ describe('notification route', () => {
     const { cleanup } = renderRoute({ initialPath: '/notification' });
 
     try {
-      await screen.findByText('Razor templates, MJML, and SMTP in one shared flow');
+      await screen.findByText(
+        'Razor templates, MJML, and SMTP in one shared flow'
+      );
 
       fireEvent.click(
         screen.getByRole('button', { name: 'Send Notification Email' })
@@ -153,6 +161,50 @@ describe('notification route', () => {
           'The notification endpoint is only available in development.'
         )
       ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('posts five dummy rows to the table notification endpoint', async () => {
+    let postedBody: Record<string, unknown> | undefined;
+
+    server.use(
+      http.get('/api/user/me', () =>
+        HttpResponse.json({
+          email: 'signed-in@example.com',
+          id: 'user-1',
+          name: 'Taylor',
+          roles: [],
+        })
+      ),
+      http.post('/api/notification/table', async ({ request }) => {
+        postedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ to: 'signed-in@example.com' });
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/notification' });
+
+    try {
+      await screen.findByText(
+        'Razor templates, MJML, and SMTP in one shared flow'
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Send Table Example Email' })
+      );
+
+      expect(
+        await screen.findByText(/Table example email sent to/i)
+      ).toBeInTheDocument();
+      expect(postedBody).toMatchObject({
+        header: 'Five-row statement example',
+        subject: 'Table notification example',
+        to: '',
+        totalAmount: 950,
+      });
+      expect(postedBody?.rows).toHaveLength(5);
     } finally {
       cleanup();
     }

--- a/server.core/Notification/NotificationService.cs
+++ b/server.core/Notification/NotificationService.cs
@@ -140,6 +140,7 @@ public sealed class NotificationService : INotificationService
         {
             AppName = appName,
             Header = header,
+            LayoutWidth = "800px",
             Message = message,
             Rows = rows,
             TotalAmount = totalAmount,

--- a/server.core/Notification/NotificationService.cs
+++ b/server.core/Notification/NotificationService.cs
@@ -125,7 +125,7 @@ public sealed class NotificationService : INotificationService
             throw new ValidationException("At least one table row is required.");
         }
 
-        if (rows.Any(row => string.IsNullOrWhiteSpace(row.Title) || string.IsNullOrWhiteSpace(row.Details)))
+        if (rows.Any(row => row is null || string.IsNullOrWhiteSpace(row.Title) || string.IsNullOrWhiteSpace(row.Details)))
         {
             throw new ValidationException("Each table row requires a title and details.");
         }

--- a/server.core/Notification/NotificationService.cs
+++ b/server.core/Notification/NotificationService.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Microsoft.Extensions.Options;
 
 namespace Server.Core.Notification;
@@ -11,11 +12,22 @@ public interface INotificationService
         string header,
         string message,
         CancellationToken cancellationToken = default);
+
+    Task SendTableAsync(
+        EmailRecipients recipients,
+        string subject,
+        string header,
+        string message,
+        IReadOnlyList<NotificationTableRow> rows,
+        decimal totalAmount,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed class NotificationService : INotificationService
 {
     private const string DefaultTemplatePath = "/Views/Emails/DefaultNotification_mjml.cshtml";
+    private const string TableTemplatePath = "/Views/Emails/TableNotification_mjml.cshtml";
+    private static readonly CultureInfo CurrencyCulture = CultureInfo.GetCultureInfo("en-US");
 
     private readonly IEmailService _emailService;
     private readonly NotificationOptions _notificationOptions;
@@ -77,6 +89,85 @@ public sealed class NotificationService : INotificationService
         var textBody = $"{header}{Environment.NewLine}{Environment.NewLine}{message}";
         var htmlBody = await _notificationRenderer.RenderAsync(
             DefaultTemplatePath,
+            model,
+            cancellationToken);
+
+        await _emailService.SendAsync(new EmailMessage
+        {
+            Recipients = recipients,
+            Subject = subject,
+            TextBody = textBody,
+            HtmlBody = htmlBody,
+        }, cancellationToken);
+    }
+
+    public async Task SendTableAsync(
+        EmailRecipients recipients,
+        string subject,
+        string header,
+        string message,
+        IReadOnlyList<NotificationTableRow> rows,
+        decimal totalAmount,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            throw new ValidationException("Notification subject is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(header))
+        {
+            throw new ValidationException("Notification header is required.");
+        }
+
+        if (rows.Count == 0)
+        {
+            throw new ValidationException("At least one table row is required.");
+        }
+
+        if (rows.Any(row => string.IsNullOrWhiteSpace(row.Title) || string.IsNullOrWhiteSpace(row.Details)))
+        {
+            throw new ValidationException("Each table row requires a title and details.");
+        }
+
+        EmailValidation.ValidateRecipients(recipients);
+
+        var appName = string.IsNullOrWhiteSpace(_notificationOptions.DefaultAppName)
+            ? _smtpOptions.FromName
+            : _notificationOptions.DefaultAppName;
+
+        var model = new TableNotificationTemplateModel
+        {
+            AppName = appName,
+            Header = header,
+            Message = message,
+            Rows = rows,
+            TotalAmount = totalAmount,
+            ButtonText = string.IsNullOrWhiteSpace(_notificationOptions.BaseUrl) ? string.Empty : _notificationOptions.DefaultButtonText,
+            ButtonUrl = _notificationOptions.BaseUrl,
+        };
+
+
+        var textLines = new List<string>
+        {
+            header,
+        };
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            textLines.Add(string.Empty);
+            textLines.Add(message);
+        }
+
+        textLines.Add(string.Empty);
+        textLines.AddRange(rows.Select(row =>
+            $"- {row.Title}: {row.Details} ({row.Amount.ToString("C2", CurrencyCulture)})"));
+        textLines.Add(string.Empty);
+        textLines.Add($"Total: {totalAmount.ToString("C2", CurrencyCulture)}");
+
+        var textBody = string.Join(Environment.NewLine, textLines);
+        var htmlBody = await _notificationRenderer.RenderAsync(
+            TableTemplatePath,
             model,
             cancellationToken);
 

--- a/server.core/Notification/NotificationTemplateModels.cs
+++ b/server.core/Notification/NotificationTemplateModels.cs
@@ -5,6 +5,7 @@ public abstract class NotificationTemplateModelBase
     public string AppName { get; init; } = string.Empty;
     public string ButtonText { get; init; } = string.Empty;
     public string ButtonUrl { get; init; } = string.Empty;
+    public string? LayoutWidth { get; init; }
 }
 
 public sealed class DefaultNotificationTemplateModel : NotificationTemplateModelBase

--- a/server.core/Notification/NotificationTemplateModels.cs
+++ b/server.core/Notification/NotificationTemplateModels.cs
@@ -1,12 +1,36 @@
 namespace Server.Core.Notification;
 
-public sealed class DefaultNotificationTemplateModel
+public abstract class NotificationTemplateModelBase
 {
     public string AppName { get; init; } = string.Empty;
-    public string Header { get; init; } = string.Empty;
-    public IReadOnlyList<string> Paragraphs { get; init; } = [];
     public string ButtonText { get; init; } = string.Empty;
     public string ButtonUrl { get; init; } = string.Empty;
+}
+
+public sealed class DefaultNotificationTemplateModel : NotificationTemplateModelBase
+{
+    public string Header { get; init; } = string.Empty;
+    public IReadOnlyList<string> Paragraphs { get; init; } = [];
+
+}
+
+public sealed class TableNotificationTemplateModel : NotificationTemplateModelBase
+{
+    public string Header { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public string FirstColumnHeader { get; init; } = "Item";
+    public string SecondColumnHeader { get; init; } = "Details";
+    public string AmountColumnHeader { get; init; } = "Amount";
+    public IReadOnlyList<NotificationTableRow> Rows { get; init; } = [];
+    public string TotalLabel { get; init; } = "Total";
+    public decimal TotalAmount { get; init; }
+}
+
+public sealed class NotificationTableRow
+{
+    public string Title { get; init; } = string.Empty;
+    public string Details { get; init; } = string.Empty;
+    public decimal Amount { get; init; }
 }
 
 public sealed class NotificationButtonModel

--- a/server.core/Views/Emails/TableNotification_mjml.cshtml
+++ b/server.core/Views/Emails/TableNotification_mjml.cshtml
@@ -1,0 +1,67 @@
+@using System.Globalization
+@model Server.Core.Notification.TableNotificationTemplateModel
+
+@{
+    Layout = "/Views/Shared/_NotificationLayout_mjml.cshtml";
+    var currencyCulture = CultureInfo.GetCultureInfo("en-US");
+}
+
+<mj-section padding="36px 36px 12px 36px">
+    <mj-column>
+        <mj-text font-size="26px" font-weight="700" line-height="1.3" padding-bottom="12px">
+            @Model.Header
+        </mj-text>
+        @if (!string.IsNullOrWhiteSpace(Model.Message))
+        {
+            <mj-text padding="0px 0px 20px 0px">
+                @Model.Message
+            </mj-text>
+        }
+        <mj-table cellpadding="0" cellspacing="0" font-size="14px" line-height="1.5" role="presentation"
+                  table-layout="fixed" padding="0px">
+            <tr style="border-bottom:1px solid #d8e1ec;">
+                <th align="left" width="30%"
+                    style="padding:0 12px 12px 0;color:#5d6b82;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
+                    @Model.FirstColumnHeader
+                </th>
+                <th align="left" width="50%"
+                    style="padding:0 16px 12px 12px;color:#5d6b82;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;">
+                    @Model.SecondColumnHeader
+                </th>
+                <th align="right" width="20%"
+                    style="padding:0 0 12px 12px;color:#5d6b82;font-size:12px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;">
+                    @Model.AmountColumnHeader
+                </th>
+            </tr>
+            @foreach (var row in Model.Rows)
+            {
+                <tr style="border-bottom:1px solid #eef3f8;vertical-align:top;">
+                    <td style="padding:14px 12px 14px 0;color:#172033;font-weight:600;">
+                        @row.Title
+                    </td>
+                    <td style="padding:14px 16px 14px 12px;color:#5d6b82;">
+                        @row.Details
+                    </td>
+                    <td align="right" style="padding:14px 0 14px 12px;color:#172033;font-weight:600;white-space:nowrap;">
+                        @row.Amount.ToString("C2", currencyCulture)
+                    </td>
+                </tr>
+            }
+            <tr>
+                <td colspan="2"
+                    style="padding:18px 16px 0 0;color:#172033;font-size:16px;font-weight:700;text-align:right;">
+                    @Model.TotalLabel
+                </td>
+                <td align="right"
+                    style="padding:18px 0 0 12px;color:#0b5fff;font-size:16px;font-weight:700;white-space:nowrap;">
+                    @Model.TotalAmount.ToString("C2", currencyCulture)
+                </td>
+            </tr>
+        </mj-table>
+    </mj-column>
+</mj-section>
+
+@if (!string.IsNullOrWhiteSpace(Model.ButtonText) && !string.IsNullOrWhiteSpace(Model.ButtonUrl))
+{
+    @await Html.PartialAsync("/Views/Shared/_NotificationButton_mjml.cshtml", new Server.Core.Notification.NotificationButtonModel(Model.ButtonText, Model.ButtonUrl))
+}

--- a/server.core/Views/Shared/_NotificationButton_mjml.cshtml
+++ b/server.core/Views/Shared/_NotificationButton_mjml.cshtml
@@ -3,11 +3,11 @@
 <mj-section background-color="#ffffff" padding="0px 0px 28px 0px">
   <mj-column>
     <mj-divider border-color="#dfe7f1" padding="0px 28px 20px 28px" />
-    <mj-button background-color="#0b5fff"
+    <mj-button background-color="#0047ba"
                color="#ffffff"
                font-size="16px"
                font-weight="600"
-               border-radius="999px"
+           border-radius="8px"
                href="@Model.Url"
                padding="0px 24px"
                inner-padding="14px 30px">

--- a/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
+++ b/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
@@ -6,9 +6,9 @@
     <mj-attributes>
       <mj-all font-family="Helvetica, Arial, sans-serif" />
       <mj-text color="#172033" font-size="16px" line-height="1.65" />
-      <mj-button background-color="#0b5fff"
+      <mj-button background-color="#0047ba"
                  color="#ffffff"
-                 border-radius="999px"
+             border-radius="8px"
                  font-size="16px"
                  font-weight="600"
                  inner-padding="14px 30px" />

--- a/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
+++ b/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
@@ -1,4 +1,4 @@
-@model Server.Core.Notification.DefaultNotificationTemplateModel
+@model Server.Core.Notification.NotificationTemplateModelBase
 <!doctype html>
 <mjml>
   <mj-head>

--- a/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
+++ b/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
@@ -14,7 +14,8 @@
                  inner-padding="14px 30px" />
     </mj-attributes>
   </mj-head>
-  <mj-body background-color="#eef3f8">
+  <mj-body background-color="#eef3f8"
+           width="@(string.IsNullOrWhiteSpace(Model.LayoutWidth) ? "600px" : Model.LayoutWidth)">
     <mj-section padding-top="40px" padding-bottom="16px">
       <mj-column>
         <mj-text align="center"

--- a/server/Controllers/NotificationController.cs
+++ b/server/Controllers/NotificationController.cs
@@ -69,6 +69,59 @@ public sealed class NotificationController : ApiControllerBase
         });
     }
 
+    [HttpPost("table")]
+    [ProducesResponseType(typeof(SendSampleNotificationResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SendTableSample(
+        [FromBody] TableNotificationRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!_environment.IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        var resolvedRecipient = ResolveRecipient(request.To);
+        if (string.IsNullOrWhiteSpace(resolvedRecipient))
+        {
+            return BadRequest("No email recipient was provided and the current user does not have an email claim.");
+        }
+
+        try
+        {
+            await _notificationService.SendTableAsync(new EmailRecipients
+            {
+                To = [resolvedRecipient],
+            }, request.Subject, request.Header, request.Message,
+            request.Rows.Select(row => new NotificationTableRow
+            {
+                Title = row.Title,
+                Details = row.Details,
+                Amount = row.Amount,
+            }).ToArray(), request.TotalAmount, cancellationToken);
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deliver table notification email to {Recipient}.", resolvedRecipient);
+            return StatusCode(StatusCodes.Status502BadGateway,
+                "The notification email could not be sent due to a delivery error.");
+        }
+
+        return Ok(new SendSampleNotificationResponse
+        {
+            To = resolvedRecipient,
+        });
+    }
+
     private string? ResolveRecipient(string? requestedRecipient)
     {
         if (!string.IsNullOrWhiteSpace(requestedRecipient))

--- a/server/Models/Notification/TableNotificationRequest.cs
+++ b/server/Models/Notification/TableNotificationRequest.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Server.Models.Notification;
+
+public sealed class TableNotificationRequest
+{
+    private string? _to;
+
+    [EmailAddress]
+    public string? To
+    {
+        get => _to;
+        init => _to = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    [Required]
+    public string Subject { get; init; } = string.Empty;
+
+    [Required]
+    public string Header { get; init; } = string.Empty;
+
+    public string Message { get; init; } = string.Empty;
+
+    [MinLength(1)]
+    public IReadOnlyList<TableNotificationRowRequest> Rows { get; init; } = [];
+
+    public decimal TotalAmount { get; init; }
+}
+
+public sealed class TableNotificationRowRequest
+{
+    [Required]
+    public string Title { get; init; } = string.Empty;
+
+    [Required]
+    public string Details { get; init; } = string.Empty;
+
+    public decimal Amount { get; init; }
+}

--- a/server/Models/Notification/TableNotificationRequest.cs
+++ b/server/Models/Notification/TableNotificationRequest.cs
@@ -21,6 +21,7 @@ public sealed class TableNotificationRequest
 
     public string Message { get; init; } = string.Empty;
 
+    [Required]
     [MinLength(1)]
     public IReadOnlyList<TableNotificationRowRequest> Rows { get; init; } = [];
 

--- a/tests/server.tests/Notification/NotificationControllerTests.cs
+++ b/tests/server.tests/Notification/NotificationControllerTests.cs
@@ -165,6 +165,54 @@ public class NotificationControllerTests
         badRequestResult.Value.Should().Be("Notification subject is required.");
     }
 
+    [Fact]
+    public async Task Table_endpoint_uses_current_user_email_and_passes_rows_and_total()
+    {
+        var notificationService = new FakeNotificationService();
+        var controller = CreateController(
+            environmentName: Environments.Development,
+            notificationService: notificationService,
+            claims:
+            [
+                new Claim("preferred_username", "person@example.com"),
+            ]);
+
+        var result = await controller.SendTableSample(new TableNotificationRequest
+        {
+            Subject = "Subject",
+            Header = "Header",
+            Message = "Summary message",
+            Rows =
+            [
+                new TableNotificationRowRequest
+                {
+                    Title = "Design",
+                    Details = "Initial exploration",
+                    Amount = 75m,
+                },
+                new TableNotificationRowRequest
+                {
+                    Title = "Build",
+                    Details = "Implementation",
+                    Amount = 125m,
+                },
+            ],
+            TotalAmount = 200m,
+        }, CancellationToken.None);
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeOfType<SendSampleNotificationResponse>()
+            .Which.To.Should().Be("person@example.com");
+
+        notificationService.TableInvocations.Should().ContainSingle();
+        notificationService.TableInvocations[0].Recipients.To.Should().Equal("person@example.com");
+        notificationService.TableInvocations[0].Subject.Should().Be("Subject");
+        notificationService.TableInvocations[0].Header.Should().Be("Header");
+        notificationService.TableInvocations[0].Message.Should().Be("Summary message");
+        notificationService.TableInvocations[0].Rows.Should().ContainSingle(row => row.Title == "Design" && row.Details == "Initial exploration" && row.Amount == 75m);
+        notificationService.TableInvocations[0].TotalAmount.Should().Be(200m);
+    }
+
     private static NotificationController CreateController(
         string environmentName,
         INotificationService notificationService,
@@ -189,6 +237,7 @@ public class NotificationControllerTests
     private sealed class FakeNotificationService : INotificationService
     {
         public List<Invocation> Invocations { get; } = [];
+        public List<TableInvocation> TableInvocations { get; } = [];
 
         public Task SendAsync(
             EmailRecipients recipients,
@@ -198,6 +247,19 @@ public class NotificationControllerTests
             CancellationToken cancellationToken = default)
         {
             Invocations.Add(new Invocation(recipients, subject, header, message));
+            return Task.CompletedTask;
+        }
+
+        public Task SendTableAsync(
+            EmailRecipients recipients,
+            string subject,
+            string header,
+            string message,
+            IReadOnlyList<NotificationTableRow> rows,
+            decimal totalAmount,
+            CancellationToken cancellationToken = default)
+        {
+            TableInvocations.Add(new TableInvocation(recipients, subject, header, message, rows, totalAmount));
             return Task.CompletedTask;
         }
     }
@@ -216,6 +278,18 @@ public class NotificationControllerTests
             string subject,
             string header,
             string message,
+            CancellationToken cancellationToken = default)
+        {
+            throw _exception;
+        }
+
+        public Task SendTableAsync(
+            EmailRecipients recipients,
+            string subject,
+            string header,
+            string message,
+            IReadOnlyList<NotificationTableRow> rows,
+            decimal totalAmount,
             CancellationToken cancellationToken = default)
         {
             throw _exception;
@@ -240,4 +314,12 @@ public class NotificationControllerTests
         string Subject,
         string Header,
         string Message);
+
+    private sealed record TableInvocation(
+        EmailRecipients Recipients,
+        string Subject,
+        string Header,
+        string Message,
+        IReadOnlyList<NotificationTableRow> Rows,
+        decimal TotalAmount);
 }

--- a/tests/server.tests/Notification/NotificationControllerTests.cs
+++ b/tests/server.tests/Notification/NotificationControllerTests.cs
@@ -209,7 +209,13 @@ public class NotificationControllerTests
         notificationService.TableInvocations[0].Subject.Should().Be("Subject");
         notificationService.TableInvocations[0].Header.Should().Be("Header");
         notificationService.TableInvocations[0].Message.Should().Be("Summary message");
-        notificationService.TableInvocations[0].Rows.Should().ContainSingle(row => row.Title == "Design" && row.Details == "Initial exploration" && row.Amount == 75m);
+        notificationService.TableInvocations[0].Rows.Should().HaveCount(2);
+        notificationService.TableInvocations[0].Rows[0].Title.Should().Be("Design");
+        notificationService.TableInvocations[0].Rows[0].Details.Should().Be("Initial exploration");
+        notificationService.TableInvocations[0].Rows[0].Amount.Should().Be(75m);
+        notificationService.TableInvocations[0].Rows[1].Title.Should().Be("Build");
+        notificationService.TableInvocations[0].Rows[1].Details.Should().Be("Implementation");
+        notificationService.TableInvocations[0].Rows[1].Amount.Should().Be(125m);
         notificationService.TableInvocations[0].TotalAmount.Should().Be(200m);
     }
 

--- a/tests/server.tests/Notification/NotificationServiceTests.cs
+++ b/tests/server.tests/Notification/NotificationServiceTests.cs
@@ -83,6 +83,63 @@ public class NotificationServiceTests
         model.ButtonUrl.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task SendTableAsync_renders_the_table_template_and_sends_the_email()
+    {
+        var emailService = new CaptureEmailService();
+        var notificationRenderer = new CaptureNotificationRenderer();
+        var service = new NotificationService(
+            emailService,
+            notificationRenderer,
+            Options.Create(new NotificationOptions
+            {
+                DefaultAppName = "Notification Center",
+            }),
+            Options.Create(new SmtpOptions
+            {
+                FromName = "Template App",
+            }));
+
+        await service.SendTableAsync(new EmailRecipients
+        {
+            To = ["person@example.com"],
+        },
+        "Statement subject",
+        "Weekly project summary",
+        "Five sample rows are rendered into the MJML table.",
+        [
+            new NotificationTableRow
+            {
+                Title = "Kickoff",
+                Details = "Planning and alignment",
+                Amount = 125.50m,
+            },
+            new NotificationTableRow
+            {
+                Title = "Build",
+                Details = "Implementation sprint",
+                Amount = 340m,
+            },
+        ],
+        465.50m);
+
+        notificationRenderer.TemplatePath.Should().Be("/Views/Emails/TableNotification_mjml.cshtml");
+        notificationRenderer.Model.Should().BeOfType<TableNotificationTemplateModel>();
+
+        var model = (TableNotificationTemplateModel)notificationRenderer.Model!;
+        model.AppName.Should().Be("Notification Center");
+        model.Header.Should().Be("Weekly project summary");
+        model.Message.Should().Be("Five sample rows are rendered into the MJML table.");
+        model.Rows.Should().HaveCount(2);
+        model.TotalAmount.Should().Be(465.50m);
+
+        emailService.Message.Should().NotBeNull();
+        emailService.Message!.Subject.Should().Be("Statement subject");
+        emailService.Message.TextBody.Should().Contain("Kickoff");
+        emailService.Message.TextBody.Should().Contain("Total: $465.50");
+        emailService.Message.HtmlBody.Should().Be(CaptureNotificationRenderer.RenderedHtml);
+    }
+
     private sealed class CaptureEmailService : IEmailService
     {
         public EmailMessage? Message { get; private set; }

--- a/tests/server.tests/Notification/NotificationServiceTests.cs
+++ b/tests/server.tests/Notification/NotificationServiceTests.cs
@@ -129,6 +129,7 @@ public class NotificationServiceTests
         var model = (TableNotificationTemplateModel)notificationRenderer.Model!;
         model.AppName.Should().Be("Notification Center");
         model.Header.Should().Be("Weekly project summary");
+        model.LayoutWidth.Should().Be("800px");
         model.Message.Should().Be("Five sample rows are rendered into the MJML table.");
         model.Rows.Should().HaveCount(2);
         model.TotalAmount.Should().Be(465.50m);

--- a/tests/server.tests/Notification/RazorMjmlNotificationRendererTests.cs
+++ b/tests/server.tests/Notification/RazorMjmlNotificationRendererTests.cs
@@ -46,4 +46,60 @@ public class RazorMjmlNotificationRendererTests
         html.Should().Contain("This is a rendered email body.");
         html.Should().NotContain("<mjml");
     }
+
+    [Fact]
+    public async Task RenderAsync_renders_html_from_the_table_template()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{SmtpOptions.SectionName}:Host"] = "sandbox.smtp.mailtrap.io",
+                [$"{SmtpOptions.SectionName}:Port"] = "587",
+                [$"{SmtpOptions.SectionName}:Username"] = "smtp-user",
+                [$"{SmtpOptions.SectionName}:Password"] = "smtp-password",
+                [$"{SmtpOptions.SectionName}:FromEmail"] = "no-reply@example.test",
+                [$"{SmtpOptions.SectionName}:FromName"] = "Template App",
+            })
+            .Build();
+
+        services.AddLogging();
+        services.AddNotificationServices(configuration);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+
+        var renderer = scope.ServiceProvider.GetRequiredService<INotificationRenderer>();
+
+        var html = await renderer.RenderAsync("/Views/Emails/TableNotification_mjml.cshtml", new TableNotificationTemplateModel
+        {
+            AppName = "Template App",
+            Header = "Statement",
+            Message = "A dynamic table is rendered below.",
+            Rows =
+            [
+                new NotificationTableRow
+                {
+                    Title = "Design",
+                    Details = "Wireframes and feedback",
+                    Amount = 90m,
+                },
+                new NotificationTableRow
+                {
+                    Title = "Build",
+                    Details = "Frontend and backend implementation",
+                    Amount = 240m,
+                },
+            ],
+            TotalAmount = 330m,
+        });
+
+        html.Should().Contain("Statement");
+        html.Should().Contain("A dynamic table is rendered below.");
+        html.Should().Contain("Design");
+        html.Should().Contain("Wireframes and feedback");
+        html.Should().Contain("$330.00");
+        html.Should().NotContain("border-collapse:collapse;width:100%;");
+        html.Should().NotContain("<mjml");
+    }
 }

--- a/tests/server.tests/Notification/RazorMjmlNotificationRendererTests.cs
+++ b/tests/server.tests/Notification/RazorMjmlNotificationRendererTests.cs
@@ -75,6 +75,7 @@ public class RazorMjmlNotificationRendererTests
         {
             AppName = "Template App",
             Header = "Statement",
+            LayoutWidth = "640px",
             Message = "A dynamic table is rendered below.",
             Rows =
             [
@@ -99,6 +100,7 @@ public class RazorMjmlNotificationRendererTests
         html.Should().Contain("Design");
         html.Should().Contain("Wireframes and feedback");
         html.Should().Contain("$330.00");
+        html.Should().Contain("width:640px");
         html.Should().NotContain("border-collapse:collapse;width:100%;");
         html.Should().NotContain("<mjml");
     }


### PR DESCRIPTION
This introduces a new MJML template, API endpoint, and client-side demonstration for sending emails that contain structured tabular data. It serves as an example for implementing more complex email layouts beyond simple paragraphs.

<img width="994" height="1276" alt="image" src="https://github.com/user-attachments/assets/11e6133a-cf5b-4b4e-97ed-f02b15ca331b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table notification feature: send formatted emails containing multi-row tables with title, details, per-row amounts, and a computed total (currency formatted).
  * UI: "Send Table Example Email" button, with pending/disabled state, success and error alerts, and a preview of the table-based message.
  * Validation and reliable delivery handling for table notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->