### PR TITLE
Add cache headers for static assets and SPA fallback

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -95,7 +95,41 @@ try
 
     app.UseForwardedHeaders();
 
-    app.UseStaticFiles();
+    app.Use(async (context, next) =>
+    {
+        context.Response.OnStarting(() =>
+        {
+            if (context.Response.StatusCode == StatusCodes.Status404NotFound &&
+                IsAssetRequest(context.Request.Path))
+            {
+                ApplyNoStoreHeaders(context);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await next();
+    });
+
+    var staticFileOptions = new StaticFileOptions
+    {
+        OnPrepareResponse = context =>
+        {
+            if (string.Equals(context.File.Name, "index.html", StringComparison.OrdinalIgnoreCase))
+            {
+                ApplyNoStoreHeaders(context.Context);
+                return;
+            }
+
+            if (IsAssetRequest(context.Context.Request.Path))
+            {
+                context.Context.Response.Headers.CacheControl = "public,max-age=31536000,immutable";
+            }
+        }
+    };
+
+    app.UseDefaultFiles();
+    app.UseStaticFiles(staticFileOptions);
 
     app.UseResponseCaching();
 
@@ -108,8 +142,6 @@ try
     }
     else
     {
-        app.UseDefaultFiles();
-
         // only use HTTPS redirection in non-development environments
         app.UseHttpsRedirection();
     }
@@ -135,12 +167,7 @@ try
         NoStore = false,
     });
 
-
-    if (!app.Environment.IsDevelopment())
-    {
-        // In production, fallback to index.html for SPA routing
-        app.MapFallbackToFile("/index.html");
-    }
+    app.MapFallbackToFile("/index.html", staticFileOptions);
 
     app.Logger.LogInformation("Startup complete. Listening on {Urls}", string.Join(", ", app.Urls));
     app.Run();
@@ -150,4 +177,19 @@ catch (Exception ex)
 {
     StartupLoggingHelper.LogStartupFailure(app, ex);
     throw;
+}
+
+static bool IsAssetRequest(PathString path)
+{
+    var value = path.Value;
+    return value is not null &&
+           (string.Equals(value, "/assets", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase));
+}
+
+static void ApplyNoStoreHeaders(HttpContext context)
+{
+    context.Response.Headers.CacheControl = "no-store,max-age=0";
+    context.Response.Headers.Pragma = "no-cache";
+    context.Response.Headers.Expires = "0";
 }


### PR DESCRIPTION
## Summary
- Set long-lived immutable caching for /assets responses.
- Apply no-store headers to index.html and 404s for asset paths to avoid stale client caching.
- Reuse the same static file response behavior for the SPA fallback route.

## Testing
- dotnet test
- npm --prefix client run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved caching for app pages and assets, helping returning visitors load content faster.

* **Bug Fixes**
  * Prevented outdated app files from being served after a missing asset request.
  * Ensured the main app entry page is always delivered consistently across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->