### PR TITLE
Prevent new apps from authenticating as template app

### DIFF
--- a/README.customization.md
+++ b/README.customization.md
@@ -42,6 +42,8 @@ Then update `server/appsettings.json`:
 }
 ```
 
+The template default for `Auth:ClientId` is a placeholder on purpose. Replace it with the **Application (client) ID** from the user sign-in app registration, or override it locally with `Auth__ClientId` in `server/.env`.
+
 If you change `CallbackPath`, remember to mirror it in the Entra redirect URIs.
 
 The Azure deployment bootstrap in section 5 automates a different Entra application/service principal for GitHub Actions OIDC. Do not use that bootstrap `clientId` as `Auth:ClientId` unless you intentionally combined the deployment identity and the user sign-in app registration, which is not the default setup.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Useful companion commands:
 
 ### Auth Configuration
 
-The app uses OIDC with Microsoft Entra ID (Azure AD). The default settings in `appsettings.*.json` are enough for local template development.
+The app uses OIDC with Microsoft Entra ID (Azure AD). The template intentionally ships with a placeholder `Auth:ClientId`; replace it with your app registration's client ID before testing sign-in so copied projects cannot accidentally authenticate as the template app.
 
 For a new application registration, redirect URIs, and app-specific auth settings, follow [the customization guide](README.customization.md#3-microsoft-entra-id-azure-ad-setup).
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,6 +4,9 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <apikey>"
 OTEL_SERVICE_NAME="<service_name>"
 OTEL_RESOURCE_ATTRIBUTES="deployment.environment=Development,service.namespace=<service_namespace>"
 
+# auth
+Auth__ClientId="<client-guid>"
+
 # database
 DB_CONNECTION="Server=localhost,14333;Database=AppDb;User ID=sa;Password=LocalDev123!;Encrypt=False;TrustServerCertificate=True;"
 

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -22,6 +22,8 @@ try
         .AddEnvFile($".env.{builder.Environment.EnvironmentName}", optional: true) // env-specific secrets
         .AddEnvironmentVariables(); // OS env vars override everything
 
+    ValidateAuthConfiguration(builder.Configuration);
+
     // setup logging and telemetry
     TelemetryHelper.ConfigureLogging(builder.Logging);
     TelemetryHelper.ConfigureOpenTelemetry(builder.Services);
@@ -192,4 +194,16 @@ static void ApplyNoStoreHeaders(HttpContext context)
     context.Response.Headers.CacheControl = "no-store,max-age=0";
     context.Response.Headers.Pragma = "no-cache";
     context.Response.Headers.Expires = "0";
+}
+
+static void ValidateAuthConfiguration(IConfiguration configuration)
+{
+    var clientId = configuration["Auth:ClientId"]?.Trim();
+
+    if (string.IsNullOrWhiteSpace(clientId) ||
+        string.Equals(clientId, "<client-guid>", StringComparison.OrdinalIgnoreCase))
+    {
+        throw new InvalidOperationException(
+            "Auth:ClientId is not configured. Replace the placeholder in server/appsettings.json or set the Auth__ClientId environment variable.");
+    }
 }

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -9,7 +9,7 @@
     "Instance": "https://login.microsoftonline.com/",
     "Domain": "ucdavis.edu",
     "TenantId": "a8046f64-66c0-4f00-9046-c8daf92ff62b",
-    "ClientId": "78531534-e937-4532-b687-0bf183d777c6",
+    "ClientId": "<client-guid>",
     "CallbackPath": "/signin-oidc"
   },
   "Smtp": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup instructions for sign-in configuration.
  * Noted that the default client ID is a placeholder and must be replaced with your app registration’s client ID.
  * Added guidance for overriding the client ID locally through environment settings.

* **Chores**
  * Updated sample configuration values to use placeholder client ID entries.
  * Added a matching environment variable example for local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->