### PR TITLE
feat: add example to display custom IAM ID claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The app uses OIDC with Microsoft Entra ID (Azure AD). The default settings in `a
 
 For a new application registration, redirect URIs, and app-specific auth settings, follow [the customization guide](README.customization.md#3-microsoft-entra-id-azure-ad-setup).
 
+To include the `ucdPersonIAMID` claim shown on the main page, follow [Authentication](https://app.notion.com/p/caes-cru/Authentication-2eae70f674118020ba74e953828d2591?source=copy_link).
+
 ### Google Analytics (GA4)
 
 This template includes GA4 wiring:

--- a/client/src/queries/user.ts
+++ b/client/src/queries/user.ts
@@ -1,7 +1,13 @@
 import { fetchJson } from '../lib/api.ts';
 import { useQuery } from '@tanstack/react-query';
 
-export type User = { email: string; id: string; name: string; roles: string[] };
+export type User = {
+  email: string;
+  iamId: string | null;
+  id: string;
+  name: string;
+  roles: string[];
+};
 
 export const meQueryOptions = () => ({
   queryFn: async (): Promise<User> => {

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ const authenticatedFetchRoute = authenticatedFetchRouteImport.update({
 } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof authenticatedIndexRoute
   '/about': typeof AboutRoute
   '/fetch': typeof authenticatedFetchRoute
   '/form': typeof authenticatedFormRoute
@@ -74,7 +75,6 @@ export interface FileRoutesByFullPath {
   '/notification': typeof authenticatedNotificationRoute
   '/styles': typeof authenticatedStylesRoute
   '/table-export': typeof authenticatedTableExportRoute
-  '/': typeof authenticatedIndexRoute
 }
 export interface FileRoutesByTo {
   '/about': typeof AboutRoute
@@ -101,6 +101,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/about'
     | '/fetch'
     | '/form'
@@ -108,7 +109,6 @@ export interface FileRouteTypes {
     | '/notification'
     | '/styles'
     | '/table-export'
-    | '/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/about'
@@ -148,8 +148,8 @@ declare module '@tanstack/react-router' {
     }
     '/(authenticated)': {
       id: '/(authenticated)'
-      path: ''
-      fullPath: ''
+      path: '/'
+      fullPath: '/'
       preLoaderRoute: typeof authenticatedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/client/src/routes/(authenticated)/index.tsx
+++ b/client/src/routes/(authenticated)/index.tsx
@@ -25,6 +25,9 @@ function RouteComponent() {
           {/* Hero Message */}
           <div className="mb-8">
             <h1 className="text-5xl font-bold mb-4">Hello {user.name}!</h1>
+            <p className="text-lg mb-4 text-base-content/70">
+              Your IAM Id: {user.iamId || 'Not Found'}
+            </p>
             <p className="text-xl max-w-2xl mx-auto text-base-content/70">
               Welcome to your modern app template. Built with Vite, React,
               TypeScript, and TanStack Router for rapid development.

--- a/server/Controllers/UserController.cs
+++ b/server/Controllers/UserController.cs
@@ -11,6 +11,7 @@ public class UserController : ApiControllerBase
         var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         var userName = User.FindFirst("name")?.Value;
         var userEmail = User.FindFirst("preferred_username")?.Value;
+        var iamId = User.FindFirst("ucdPersonIAMID")?.Value;
 
         var userRoles = User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList();
 
@@ -24,6 +25,7 @@ public class UserController : ApiControllerBase
             Id = userId,
             Name = userName,
             Email = userEmail,
+            IamId = iamId,
             Roles = userRoles,
         };
 

--- a/tests/server.tests/Controllers/UserControllerTests.cs
+++ b/tests/server.tests/Controllers/UserControllerTests.cs
@@ -1,0 +1,63 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Server.Controllers;
+
+namespace Server.Tests.Controllers;
+
+public class UserControllerTests
+{
+    [Fact]
+    public void Me_returns_iam_id_claim()
+    {
+        var controller = CreateController("123456789");
+
+        var result = controller.Me();
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(okResult.Value));
+        json.RootElement.GetProperty("IamId").GetString().Should().Be("123456789");
+    }
+
+    [Fact]
+    public void Me_returns_null_iam_id_when_claim_is_missing()
+    {
+        var controller = CreateController();
+
+        var result = controller.Me();
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(okResult.Value));
+        json.RootElement.GetProperty("IamId").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    private static UserController CreateController(string? iamId = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "user-1"),
+            new("name", "Test User"),
+            new("preferred_username", "test@example.com"),
+        };
+
+        if (iamId != null)
+        {
+            claims.Add(new Claim("ucdPersonIAMID", iamId));
+        }
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+
+        return new UserController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = user,
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
Demonstrates how to fetch and render the 'ucdPersonIAMID' custom OIDC claim. This includes API modifications, client type updates, UI integration, and documentation on how to configure the claim in Entra ID. A server-side test is also added to verify claim retrieval.